### PR TITLE
a better way to get encoder_hidden_states, ip_hidden_states

### DIFF
--- a/ip_adapter/attention_processor.py
+++ b/ip_adapter/attention_processor.py
@@ -402,9 +402,9 @@ class CNAttnProcessor:
     Default processor for performing attention-related computations.
     """
 
-    def __init__(self, text_context_len=77):
+    def __init__(self, text_context_len=77, num_tokens = 4):
         self.text_context_len = text_context_len
-
+        self.num_tokens = num_tokens
     def __call__(
         self,
         attn,
@@ -437,7 +437,8 @@ class CNAttnProcessor:
         if encoder_hidden_states is None:
             encoder_hidden_states = hidden_states
         elif attn.norm_cross:
-            encoder_hidden_states = encoder_hidden_states[:, :self.text_context_len] # only use text
+            end_pos = encoder_hidden_states.shape[1] - self.num_tokens
+            encoder_hidden_states = encoder_hidden_states[:, :end_pos] # only use text
             encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
 
         key = attn.to_k(encoder_hidden_states)
@@ -472,10 +473,11 @@ class CNAttnProcessor2_0:
     Processor for implementing scaled dot-product attention (enabled by default if you're using PyTorch 2.0).
     """
 
-    def __init__(self, text_context_len=77):
+    def __init__(self, text_context_len=77,  num_tokens = 4):
         if not hasattr(F, "scaled_dot_product_attention"):
             raise ImportError("AttnProcessor2_0 requires PyTorch 2.0, to use it, please upgrade PyTorch to 2.0.")
         self.text_context_len = text_context_len
+        self.num_tokens = num_tokens
 
     def __call__(
         self,
@@ -514,7 +516,8 @@ class CNAttnProcessor2_0:
         if encoder_hidden_states is None:
             encoder_hidden_states = hidden_states
         elif attn.norm_cross:
-            encoder_hidden_states = encoder_hidden_states[:, :self.text_context_len]
+            end_pos = encoder_hidden_states.shape[1] - self.num_tokens
+            encoder_hidden_states = encoder_hidden_states[:, :end_pos] # only use text
             encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
 
         key = attn.to_k(encoder_hidden_states)

--- a/ip_adapter/attention_processor.py
+++ b/ip_adapter/attention_processor.py
@@ -101,7 +101,7 @@ class IPAttnProcessor(nn.Module):
         self.to_k_ip = nn.Linear(cross_attention_dim or hidden_size, hidden_size, bias=False)
         self.to_v_ip = nn.Linear(cross_attention_dim or hidden_size, hidden_size, bias=False)
 
-        self.num_tokens = 4
+        self.num_tokens = num_tokens
     def __call__(
         self,
         attn,

--- a/ip_adapter/attention_processor.py
+++ b/ip_adapter/attention_processor.py
@@ -433,10 +433,11 @@ class CNAttnProcessor:
 
         if encoder_hidden_states is None:
             encoder_hidden_states = hidden_states
-        elif attn.norm_cross:
+        else:
             end_pos = encoder_hidden_states.shape[1] - self.num_tokens
             encoder_hidden_states = encoder_hidden_states[:, :end_pos] # only use text
-            encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
+            if attn.norm_cross:
+                encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
 
         key = attn.to_k(encoder_hidden_states)
         value = attn.to_v(encoder_hidden_states)
@@ -511,10 +512,11 @@ class CNAttnProcessor2_0:
 
         if encoder_hidden_states is None:
             encoder_hidden_states = hidden_states
-        elif attn.norm_cross:
+        else:
             end_pos = encoder_hidden_states.shape[1] - self.num_tokens
             encoder_hidden_states = encoder_hidden_states[:, :end_pos] # only use text
-            encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
+            if attn.norm_cross:
+                encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
 
         key = attn.to_k(encoder_hidden_states)
         value = attn.to_v(encoder_hidden_states)

--- a/ip_adapter/attention_processor.py
+++ b/ip_adapter/attention_processor.py
@@ -440,6 +440,9 @@ class CNAttnProcessor:
             end_pos = encoder_hidden_states.shape[1] - self.num_tokens
             encoder_hidden_states = encoder_hidden_states[:, :end_pos] # only use text
             encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
+        else: # get back text
+            end_pos = encoder_hidden_states.shape[1] - self.num_tokens
+            encoder_hidden_states = encoder_hidden_states[:, :end_pos] # only use text
 
         key = attn.to_k(encoder_hidden_states)
         value = attn.to_v(encoder_hidden_states)
@@ -519,6 +522,9 @@ class CNAttnProcessor2_0:
             end_pos = encoder_hidden_states.shape[1] - self.num_tokens
             encoder_hidden_states = encoder_hidden_states[:, :end_pos] # only use text
             encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
+        else: # get back text
+            end_pos = encoder_hidden_states.shape[1] - self.num_tokens
+            encoder_hidden_states = encoder_hidden_states[:, :end_pos] # only use text
 
         key = attn.to_k(encoder_hidden_states)
         value = attn.to_v(encoder_hidden_states)

--- a/ip_adapter/attention_processor.py
+++ b/ip_adapter/attention_processor.py
@@ -137,8 +137,7 @@ class IPAttnProcessor(nn.Module):
             encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
             
         # get encoder_hidden_states, ip_hidden_states
-        multi_length = (encoder_hidden_states.shape[1] - self.num_tokens) / self.text_context_len
-        end_pos = int(self.text_context_len * multi_length)
+        end_pos = encoder_hidden_states.shape[1] - self.num_tokens
         encoder_hidden_states, ip_hidden_states = encoder_hidden_states[:, :end_pos, :], encoder_hidden_states[:, end_pos:, :]
 
 
@@ -340,8 +339,7 @@ class IPAttnProcessor2_0(torch.nn.Module):
             encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
 
         # get encoder_hidden_states, ip_hidden_states
-        multi_length = (encoder_hidden_states.shape[1] - self.num_tokens) / self.text_context_len
-        end_pos = int(self.text_context_len * multi_length)
+        end_pos = encoder_hidden_states.shape[1] - self.num_tokens
         encoder_hidden_states, ip_hidden_states = encoder_hidden_states[:, :end_pos, :], encoder_hidden_states[:, end_pos:, :]
 
         key = attn.to_k(encoder_hidden_states)

--- a/ip_adapter/ip_adapter.py
+++ b/ip_adapter/ip_adapter.py
@@ -76,7 +76,7 @@ class IPAdapter:
                 attn_procs[name] = AttnProcessor()
             else:
                 attn_procs[name] = IPAttnProcessor(hidden_size=hidden_size, cross_attention_dim=cross_attention_dim,
-                scale=1.0).to(self.device, dtype=torch.float16)
+                scale=1.0,num_tokens= self.num_tokens).to(self.device, dtype=torch.float16)
         unet.set_attn_processor(attn_procs)
         if hasattr(self.pipe, "controlnet"):
             self.pipe.controlnet.set_attn_processor(CNAttnProcessor())

--- a/ip_adapter/ip_adapter.py
+++ b/ip_adapter/ip_adapter.py
@@ -79,7 +79,7 @@ class IPAdapter:
                 scale=1.0,num_tokens= self.num_tokens).to(self.device, dtype=torch.float16)
         unet.set_attn_processor(attn_procs)
         if hasattr(self.pipe, "controlnet"):
-            self.pipe.controlnet.set_attn_processor(CNAttnProcessor())
+            self.pipe.controlnet.set_attn_processor(CNAttnProcessor(num_tokens= self.num_tokens))
         
     def load_ip_adapter(self):
         state_dict = torch.load(self.ip_ckpt, map_location="cpu")


### PR DESCRIPTION
[https://github.com/huggingface/diffusers/blob/946bb53c566ef75a6c9417ca399b7e072d243c04/examples/community/lpw_stable_diffusion.py#L643](lpw_stable_diffusion) in this community pipeline the wighted prompt embedding may be longer than 77 maybe 154, So we should distinguish them according to the dimension of the picture