### PR TITLE
 Bugfix for #109 - default seed does not randomize. 

### DIFF
--- a/ip_adapter/ip_adapter.py
+++ b/ip_adapter/ip_adapter.py
@@ -114,7 +114,7 @@ class IPAdapter:
         negative_prompt=None,
         scale=1.0,
         num_samples=4,
-        seed=-1,
+        seed=None,
         guidance_scale=7.5,
         num_inference_steps=30,
         **kwargs,

--- a/ip_adapter/ip_adapter.py
+++ b/ip_adapter/ip_adapter.py
@@ -173,7 +173,7 @@ class IPAdapterXL(IPAdapter):
         negative_prompt=None,
         scale=1.0,
         num_samples=4,
-        seed=-1,
+        seed=None,
         num_inference_steps=30,
         **kwargs,
     ):
@@ -285,7 +285,7 @@ class IPAdapterPlusXL(IPAdapter):
         negative_prompt=None,
         scale=1.0,
         num_samples=4,
-        seed=-1,
+        seed=None,
         num_inference_steps=30,
         **kwargs,
     ):


### PR DESCRIPTION
One-line change to make the default seed 'random' instead of the same. (Issue #109)  Based on line 153, it looks like this was the intended behavior.  

Caveat: I have only tested the SD1.5 seed change for want of VRAM, but given the code is the same in the other methods, the fix should work for them, too.