### PR TITLE
Update ip_adapter.py

### DIFF
--- a/ip_adapter/ip_adapter.py
+++ b/ip_adapter/ip_adapter.py
@@ -3,7 +3,7 @@ from typing import List
 
 import torch
 from diffusers import StableDiffusionPipeline
-from diffusers.pipelines.controlnet import MultiControlNetModel
+from diffusers.pipelines.controlnet import multicontrolnet as MultiControlNetModel
 from PIL import Image
 from safetensors import safe_open
 from transformers import CLIPImageProcessor, CLIPVisionModelWithProjection


### PR DESCRIPTION
fix:

```
File "/ip-adapter/env/lib/python3.10/site-packages/ip_adapter/ip_adapter.py", line 6, in <module>
    from diffusers.pipelines.controlnet import MultiControlNetModel
ImportError: cannot import name 'MultiControlNetModel' from 'diffusers.pipelines.controlnet' (ip-adapter/env/lib/python3.10/site-packages/diffusers/pipelines/controlnet/__init__.py)
```