### PR TITLE
Added missing guidance_scale passing to StableDiffusionXL from IPAdapterFaceIDPlusXL pipeline

### DIFF
--- a/ip_adapter/ip_adapter_faceid.py
+++ b/ip_adapter/ip_adapter_faceid.py
@@ -531,6 +531,7 @@ class IPAdapterFaceIDPlusXL(IPAdapterFaceIDPlus):
             negative_pooled_prompt_embeds=negative_pooled_prompt_embeds,
             num_inference_steps=num_inference_steps,
             generator=generator,
+            guidance_scale=guidance_scale,
             **kwargs,
         ).images
 

--- a/ip_adapter/ip_adapter_faceid_separate.py
+++ b/ip_adapter/ip_adapter_faceid_separate.py
@@ -536,6 +536,7 @@ class IPAdapterFaceIDPlusXL(IPAdapterFaceIDPlus):
             negative_pooled_prompt_embeds=negative_pooled_prompt_embeds,
             num_inference_steps=num_inference_steps,
             generator=generator,
+            guidance_scale=guidance_scale,
             **kwargs,
         ).images
 


### PR DESCRIPTION
Hi @xiaohu2015!

I noticed that there was a missing `guidance_scale` parameter passing to `StableDiffusionXLPipeline` from `IPAdapterFaceIDPlusXL`, so I added it to these pipelines.