### PR TITLE
change resampler attention to scale_dot_product_attention

### DIFF
--- a/ip_adapter/resampler.py
+++ b/ip_adapter/resampler.py
@@ -5,6 +5,7 @@ import math
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from einops import rearrange
 from einops.layers.torch import Rearrange
 
@@ -68,10 +69,7 @@ class PerceiverAttention(nn.Module):
         v = reshape_tensor(v, self.heads)
 
         # attention
-        scale = 1 / math.sqrt(math.sqrt(self.dim_head))
-        weight = (q * scale) @ (k * scale).transpose(-2, -1)  # More stable with f16 than dividing afterwards
-        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
-        out = weight @ v
+        out = F.scale_dot_product_attention(q, k, v)
 
         out = out.permute(0, 2, 1, 3).reshape(b, l, -1)
 


### PR DESCRIPTION
I noticed two issues:

1. PerceiverAttention consumes a huge amount of memory while calculating an attention map
2. There are two operations of math.srqt when scale calculating: `scale = 1 / math.sqrt(math.sqrt(self.dim_head))`

Both of them can be fixed using more effective implementation: `F.scaled_dot_product_attention(q, k, v)`. 

PS
If you need scale with two sqrt, it can be provided as an additional argument to `F.scaled_dot_product_attention`.

